### PR TITLE
GarbageCollection hangs because #scan doesn't honor last_key argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ruby file using the following method:
 
     require 'aws-sessionstore-dynamodb'
 
-    AWS::SessionStore::DynamoDB::Table.create_table
+    Aws::SessionStore::DynamoDB::Table.create_table
 
 Run the session store as a Rack middleware in the following way:
 
@@ -46,7 +46,7 @@ Run the session store as a Rack middleware in the following way:
 
     options = { :secret_key => 'SECRET_KEY' }
 
-    use AWS::SessionStore::DynamoDB::RackMiddleware.new(options)
+    use Aws::SessionStore::DynamoDB::RackMiddleware.new(options)
     run SomeRackApp
 
 Note that `:secret_key` is a mandatory configuration option that must be set.
@@ -71,7 +71,7 @@ Full API documentation of the library can be found on [RubyDoc.info][1].
 ### Configuration Options
 
 A number of options are available to be set in
-`AWS::SessionStore::DynamoDB::Configuration`, which is used by the
+`Aws::SessionStore::DynamoDB::Configuration`, which is used by the
 `RackMiddleware` class. These options can be set in the YAML configuration
 file in a Rails application (located in `config/sessionstore/dynamodb.yml`),
 directly by Ruby code, or through environment variables.
@@ -126,7 +126,7 @@ You can create your own Rake task for garbage collection similar to below:
     desc 'Perform Garbage Collection'
     task :garbage_collect do |t|
      options = {:max_age => 3600*24, max_stale => 5*3600 }
-     AWS::SessionStore::DynamoDB::GarbageCollection.collect_garbage(options)
+     Aws::SessionStore::DynamoDB::GarbageCollection.collect_garbage(options)
     end
 
 The above example will clear sessions older than one day or that have been
@@ -164,8 +164,8 @@ locking strategy according to your needs:
 
 You can pass in your own error handler for raised exceptions or you can allow
 the default error handler to them for you. See the API documentation
-on the {AWS::SessionStore::DynamoDB::Errors::BaseHandler} class for more
+on the {Aws::SessionStore::DynamoDB::Errors::BaseHandler} class for more
 details.
 
 [1]: http://rubydoc.org/gems/aws-sessionstore-dynamodb/frames
-[2]: http://rubydoc.org/gems/aws-sessionstore-dynamodb/AWS/SessionStore/DynamoDB/Configuration#initialize-instance_method
+[2]: http://rubydoc.org/gems/aws-sessionstore-dynamodb/Aws/SessionStore/DynamoDB/Configuration#initialize-instance_method

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Amazon DynamoDB Session Store
 
 The **Amazon DynamoDB Session Store** handles sessions for Ruby web applications
-using a DynamoDB backend. The session store is compatible with Rails and other
-Rack based frameworks.
+using a DynamoDB backend. The session store is compatible with Rails (3.x or 4.x)
+and other Rack based frameworks.
 
 ## Installation
 

--- a/aws-sessionstore-dynamodb.gemspec
+++ b/aws-sessionstore-dynamodb.gemspec
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/lib/aws/session_store/dynamo_db/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "aws-sessionstore-dynamodb"
-  spec.version       = AWS::SessionStore::DynamoDB::VERSION
+  spec.version       = Aws::SessionStore::DynamoDB::VERSION
   spec.authors       = ["Ruby Robinson"]
   spec.summary       = "The Amazon DynamoDB Session Store handles sessions " +
                        "for Ruby web applications using a DynamoDB backend."
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk', '~> 1.0'
+  spec.add_dependency 'aws-sdk', '~> 2.0'
   spec.add_dependency 'rack', '~> 1.0'
 end

--- a/aws-sessionstore-dynamodb.gemspec
+++ b/aws-sessionstore-dynamodb.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk', '~> 2.0.48'
+  spec.add_dependency 'aws-sdk', '~> 2.1.2'
   spec.add_dependency 'rack', '~> 1.0'
 end

--- a/aws-sessionstore-dynamodb.gemspec
+++ b/aws-sessionstore-dynamodb.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk', '~> 2.0'
+  spec.add_dependency 'aws-sdk', '~> 2.0.48'
   spec.add_dependency 'rack', '~> 1.0'
 end

--- a/lib/aws-sessionstore-dynamodb.rb
+++ b/lib/aws-sessionstore-dynamodb.rb
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS
+module Aws
   module SessionStore
     module DynamoDB; end
   end

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -204,7 +204,8 @@ module Aws::SessionStore::DynamoDB
       dynamo_db_client = @options[:dynamo_db_client]
       if dynamo_db_client.nil?
         client_opts = client_subset(@options)
-        client_opts[:endpoint] ||= ENV['AWS_ENDPOINT'] # for DynamoDB Local
+        # Support ENV to set endpoint to DynamoDB Local
+        client_opts[:endpoint] ||= ENV['AWS_DYNAMODB_ENDPOINT'] if ENV['AWS_DYNAMODB_ENDPOINT']
         dynamo_db_client = Aws::DynamoDB::Client.new(client_opts)
       end
 

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -66,7 +66,8 @@ module Aws::SessionStore::DynamoDB
       :lock_expiry_time => 500,
       :lock_retry_delay => 500,
       :lock_max_wait_time => 1,
-      :secret_key => nil
+      :secret_key => nil,
+      :verbose => false
     }
 
     # @return [String] Session table name.
@@ -133,6 +134,9 @@ module Aws::SessionStore::DynamoDB
     #   before giving up.
     attr_reader :lock_max_wait_time
 
+    # @return [true] Info printed to stdout
+    # @return [false] Run silent, run deep
+    attr_reader :verbose
 
     # Provides configuration object that allows access to options defined
     # during Runtime, in a YAML file, in the ENV and by default.
@@ -180,6 +184,7 @@ module Aws::SessionStore::DynamoDB
     #   to wait to acquire lock before giving up.
     # @option options [String] :secret_key (SecureRandom.hex(64))
     #   Secret key for HMAC encription.
+    # @option options [Boolean] :verbose (true)
     def initialize(options = {})
       @options = default_options.merge(
       env_options.merge(

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -14,7 +14,7 @@
 require 'yaml'
 require 'aws-sdk'
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   # This class provides a Configuration object for all DynamoDB transactions
   # by pulling configuration options from Runtime, a YAML file, the ENV and
   # default settings.
@@ -66,8 +66,7 @@ module AWS::SessionStore::DynamoDB
       :lock_expiry_time => 500,
       :lock_retry_delay => 500,
       :lock_max_wait_time => 1,
-      :secret_key => nil,
-      :api_version => '2012-08-10'
+      :secret_key => nil
     }
 
     # @return [String] Session table name.
@@ -78,17 +77,17 @@ module AWS::SessionStore::DynamoDB
 
     # @return [true] If a strongly consistent read is used
     # @return [false] If an eventually consistent read is used.
-    # See AWS DynamoDB documentation for table consistent_read for more
+    # See Aws DynamoDB documentation for table consistent_read for more
     # information on this setting.
     attr_reader :consistent_read
 
     # @return [Integer] Maximum number of reads consumed per second before
-    #   DynamoDB returns a ThrottlingException. See AWS DynamoDB documentation
+    #   DynamoDB returns a ThrottlingException. See Aws DynamoDB documentation
     #   for table read_capacity for more information on this setting.
     attr_reader :read_capacity
 
     # @return [Integer] Maximum number of writes consumed per second before
-    #   DynamoDB returns a ThrottlingException. See AWS DynamoDB documentation
+    #   DynamoDB returns a ThrottlingException. See Aws DynamoDB documentation
     #   for table write_capacity for more information on this setting.
     attr_reader :write_capacity
 
@@ -102,7 +101,7 @@ module AWS::SessionStore::DynamoDB
     attr_reader :dynamo_db_client
 
     # @return [Error Handler] An error handling object that handles all exceptions
-    #   thrown during execution of the AWS DynamoDB Session Store Rack Middleware.
+    #   thrown during execution of the Aws DynamoDB Session Store Rack Middleware.
     #   For more information see the Handling Errors Section.
     attr_reader :error_handler
 
@@ -147,21 +146,21 @@ module AWS::SessionStore::DynamoDB
     #   used.
     # @option options [Integer] :read_capacity (10) The maximum number of
     #   strongly consistent reads consumed per second before
-    #   DynamoDB raises a ThrottlingException. See AWS DynamoDB documentation
+    #   DynamoDB raises a ThrottlingException. See Aws DynamoDB documentation
     #   for table read_capacity for more information on this setting.
     # @option options [Integer] :write_capacity (5) The maximum number of writes
     #   consumed per second before DynamoDB returns a ThrottlingException.
-    #   See AWS DynamoDB documentation for table write_capacity for more
+    #   See Aws DynamoDB documentation for table write_capacity for more
     #   information on this setting.
     # @option options [DynamoDB Client] :dynamo_db_client
-    #   (AWS::DynamoDB::ClientV2) DynamoDB client used to perform database
+    #   (Aws::DynamoDB::ClientV2) DynamoDB client used to perform database
     #   operations inside of middleware application.
     # @option options [Boolean] :raise_errors (false) If true, all errors are
     #   raised up the stack when default ErrorHandler. If false, Only specified
     #   errors are raised up the stack when default ErrorHandler is used.
     # @option options [Error Handler] :error_handler (DefaultErrorHandler)
     #   An error handling object that handles all exceptions thrown during
-    #   execution of the AWS DynamoDB Session Store Rack Middleware.
+    #   execution of the Aws DynamoDB Session Store Rack Middleware.
     #   For more information see the Handling Errors Section.
     # @option options [Integer] :max_age (nil) Maximum number of seconds earlier
     #   from the current time that a session was created.
@@ -203,14 +202,14 @@ module AWS::SessionStore::DynamoDB
     # @return [Hash] DDB client.
     def gen_dynamo_db_client
       client_opts = client_subset(@options)
-      client = AWS::DynamoDB::Client
+      client = Aws::DynamoDB::Client
       dynamo_db_client = @options[:dynamo_db_client] || client.new(client_opts)
       {:dynamo_db_client => dynamo_db_client}
     end
 
     # @return [Hash] Default Error Handler
     def gen_error_handler
-      default_handler = AWS::SessionStore::DynamoDB::Errors::DefaultHandler
+      default_handler = Aws::SessionStore::DynamoDB::Errors::DefaultHandler
       error_handler = @options[:error_handler] ||
                             default_handler.new(@options[:raise_errors])
       {:error_handler => error_handler}
@@ -288,7 +287,7 @@ module AWS::SessionStore::DynamoDB
 
     # @return [Hash] Client subset options hash.
     def client_subset(options = {})
-      client_keys = [:aws_secret_key, :aws_region, :aws_access_key, :api_version]
+      client_keys = [:aws_secret_key, :aws_region, :aws_access_key]
       options.inject({}) do |opts, (opt_name, opt_value)|
         opts[opt_name.to_sym] = opt_value if client_keys.include?(opt_name.to_sym)
         opts

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -204,8 +204,6 @@ module Aws::SessionStore::DynamoDB
       dynamo_db_client = @options[:dynamo_db_client]
       if dynamo_db_client.nil?
         client_opts = client_subset(@options)
-        # Support ENV to set endpoint to DynamoDB Local
-        client_opts[:endpoint] ||= ENV['AWS_DYNAMODB_ENDPOINT'] if ENV['AWS_DYNAMODB_ENDPOINT']
         dynamo_db_client = Aws::DynamoDB::Client.new(client_opts)
       end
 

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -56,6 +56,7 @@ module Aws::SessionStore::DynamoDB
     DEFAULTS = {
       :table_name => "sessions",
       :table_key => "session_id",
+      :user_key => nil,
       :consistent_read => true,
       :read_capacity => 10,
       :write_capacity => 5,
@@ -75,6 +76,9 @@ module Aws::SessionStore::DynamoDB
 
     # @return [String] Session table hash key name.
     attr_reader :table_key
+
+    # @return [String] Name of user key in session data.
+    attr_reader :user_key
 
     # @return [true] If a strongly consistent read is used
     # @return [false] If an eventually consistent read is used.
@@ -145,6 +149,7 @@ module Aws::SessionStore::DynamoDB
     #   table.
     # @option options [String] :table_key ("id") The hash key of the sesison
     #   table.
+    # @option options [String] :user_key ("id") Name of user key in session.
     # @option options [Boolean] :consistent_read (true) If true, a strongly
     #   consistent read is used. If false, an eventually consistent read is
     #   used.

--- a/lib/aws/session_store/dynamo_db/errors/base_handler.rb
+++ b/lib/aws/session_store/dynamo_db/errors/base_handler.rb
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB::Errors
+module Aws::SessionStore::DynamoDB::Errors
   # BaseErrorHandler provides an interface for error handlers
-  # that can be passed in to {AWS::SessionStore::DynamoDB::RackMiddleware}.
+  # that can be passed in to {Aws::SessionStore::DynamoDB::RackMiddleware}.
   # Each error handler must implement a handle_error method.
   #
   # @example Sample ErrorHandler class
@@ -33,11 +33,11 @@ module AWS::SessionStore::DynamoDB::Errors
     # error up the stack.
     # You may reraise the error passed.
     #
-    # @param [AWS::DynamoDB::Errors::Base] error error passed in from
-    #  AWS::SessionStore::DynamoDB::RackMiddleware.
+    # @param [Aws::DynamoDB::Errors::Base] error error passed in from
+    #  Aws::SessionStore::DynamoDB::RackMiddleware.
     # @param [Rack::Request::Environment,nil] env Rack environment
     # @return [false] If exception was handled and will not reraise exception.
-    # @raise [AWS::DynamoDB::Errors] If error has be reraised.
+    # @raise [Aws::DynamoDB::Errors] If error has be reraised.
     def handle_error(error, env = {})
       raise NotImplementedError
     end

--- a/lib/aws/session_store/dynamo_db/errors/default_handler.rb
+++ b/lib/aws/session_store/dynamo_db/errors/default_handler.rb
@@ -12,15 +12,15 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB::Errors
+module Aws::SessionStore::DynamoDB::Errors
   # This class handles errors raised from DynamoDB.
-  class DefaultHandler < AWS::SessionStore::DynamoDB::Errors::BaseHandler
+  class DefaultHandler < Aws::SessionStore::DynamoDB::Errors::BaseHandler
     # Array of errors that will always be passed up the Rack stack.
     HARD_ERRORS = [
-      AWS::DynamoDB::Errors::ResourceNotFoundException,
-      AWS::DynamoDB::Errors::ConditionalCheckFailedException,
-      AWS::SessionStore::DynamoDB::MissingSecretKeyError,
-      AWS::SessionStore::DynamoDB::LockWaitTimeoutError
+      Aws::DynamoDB::Errors::ResourceNotFoundException,
+      Aws::DynamoDB::Errors::ConditionalCheckFailedException,
+      Aws::SessionStore::DynamoDB::MissingSecretKeyError,
+      Aws::SessionStore::DynamoDB::LockWaitTimeoutError
     ]
 
     # Determines behavior of DefaultErrorHandler

--- a/lib/aws/session_store/dynamo_db/garbage_collection.rb
+++ b/lib/aws/session_store/dynamo_db/garbage_collection.rb
@@ -59,7 +59,7 @@ module Aws::SessionStore::DynamoDB
     # @api private
     def scan(config, last_item = nil)
       options = scan_opts(config)
-      options.merge(start_key(last_item)) if last_item
+      options = options.merge(start_key(last_item)) if last_item
       config.dynamo_db_client.scan(options)
     end
 

--- a/lib/aws/session_store/dynamo_db/garbage_collection.rb
+++ b/lib/aws/session_store/dynamo_db/garbage_collection.rb
@@ -50,8 +50,8 @@ module Aws::SessionStore::DynamoDB
     # @api private
     def eliminate_unwanted_sessions(config, last_key = nil)
       scan_result = scan(config, last_key)
-      batch_delete(config, scan_result[:member])
-      scan_result[:last_evaluated_key] || {}
+      batch_delete(config, scan_result.items)
+      scan_result.last_evaluated_key || {}
     end
 
     # Scans the table for sessions matching the max age and
@@ -68,6 +68,7 @@ module Aws::SessionStore::DynamoDB
     def batch_delete(config, items)
       begin
         subset = items.shift(25)
+        puts "DELETE SESSIONS #{subset.map{|i| i['id']}}" if config.verbose && !subset.empty?
         sub_batch = write(subset)
         process!(config, sub_batch)
       end until subset.empty?

--- a/lib/aws/session_store/dynamo_db/garbage_collection.rb
+++ b/lib/aws/session_store/dynamo_db/garbage_collection.rb
@@ -13,7 +13,7 @@
 
 require 'aws-sdk'
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   # Collects and deletes unwanted sessions based on
   # their creation and update dates.
   module GarbageCollection
@@ -34,7 +34,7 @@ module AWS::SessionStore::DynamoDB
     # @option (see Configuration#initialize)
     # @api private
     def load_config(options = {})
-      AWS::SessionStore::DynamoDB::Configuration.new(options)
+      Aws::SessionStore::DynamoDB::Configuration.new(options)
     end
 
     # Sets scan filter attributes based on attributes specified.
@@ -114,7 +114,7 @@ module AWS::SessionStore::DynamoDB
     # @api private
     def oldest_date(sec)
       hash = {}
-      hash[:attribute_value_list] = [:n => "#{((Time.now - sec).to_f)}"]
+      hash[:attribute_value_list] = ["#{((Time.now - sec).to_f)}"]
       hash[:comparison_operator] = 'LT'
       hash
     end

--- a/lib/aws/session_store/dynamo_db/invalid_id_error.rb
+++ b/lib/aws/session_store/dynamo_db/invalid_id_error.rb
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   class InvalidIDError < RuntimeError
     def initialize(msg = "Corrupt Session ID!")
       super

--- a/lib/aws/session_store/dynamo_db/lock_wait_timeout_error.rb
+++ b/lib/aws/session_store/dynamo_db/lock_wait_timeout_error.rb
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   class LockWaitTimeoutError < RuntimeError
     def initialize(msg = 'Maximum time spent to acquire lock has been exceeded!')
       super

--- a/lib/aws/session_store/dynamo_db/locking/base.rb
+++ b/lib/aws/session_store/dynamo_db/locking/base.rb
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB::Locking
+module Aws::SessionStore::DynamoDB::Locking
   # This class provides a framework for implementing
   # locking strategies.
   class Base
@@ -56,7 +56,7 @@ module AWS::SessionStore::DynamoDB::Locking
     def handle_error(env = nil, &block)
       begin
         yield
-      rescue AWS::DynamoDB::Errors::Base => e
+      rescue Aws::Errors::ServiceError => e
         @config.error_handler.handle_error(e, env)
       end
     end
@@ -101,7 +101,7 @@ module AWS::SessionStore::DynamoDB::Locking
     def table_opts(sid)
       {
         :table_name => @config.table_name,
-        :key => {@config.table_key => {:s => sid}}
+        :key => {@config.table_key => sid}
       }
     end
 
@@ -116,7 +116,7 @@ module AWS::SessionStore::DynamoDB::Locking
 
     # Update client with current time attribute.
     def updated_at
-      { :value => {:n => "#{(Time.now).to_f}"}, :action  => "PUT" }
+      { :value => "#{(Time.now).to_f}", :action  => "PUT" }
     end
 
     # Attribute for creation of session.
@@ -132,7 +132,7 @@ module AWS::SessionStore::DynamoDB::Locking
     end
 
     def data_attr(session)
-       { "data" => {:value => {:s => session}, :action  => "PUT"} }
+       { "data" => {:value => session, :action  => "PUT"} }
     end
 
     # Determine if data has been manipulated
@@ -143,7 +143,7 @@ module AWS::SessionStore::DynamoDB::Locking
 
     # Expected attributes
     def expected_attributes(sid)
-      { :expected => {@config.table_key => {:value => {:s => sid}, :exists => true}} }
+      { :expected => {@config.table_key => {:value => sid, :exists => true}} }
     end
 
     # Attributes to be retrieved via client

--- a/lib/aws/session_store/dynamo_db/locking/base.rb
+++ b/lib/aws/session_store/dynamo_db/locking/base.rb
@@ -93,6 +93,7 @@ module Aws::SessionStore::DynamoDB::Locking
 
     # Unmarshal the data.
     def unpack_data(packed_data)
+      return {} if packed_data.nil?
       Marshal.load(packed_data.unpack("m*").first)
     end
 

--- a/lib/aws/session_store/dynamo_db/locking/null.rb
+++ b/lib/aws/session_store/dynamo_db/locking/null.rb
@@ -12,10 +12,10 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB::Locking
+module Aws::SessionStore::DynamoDB::Locking
   # This class gets and sets sessions
   # without a locking strategy.
-  class Null < AWS::SessionStore::DynamoDB::Locking::Base
+  class Null < Aws::SessionStore::DynamoDB::Locking::Base
     # Retrieve session if it exists from the database by id.
     # Unpack the data once retrieved from the database.
     def get_session_data(env, sid)
@@ -32,8 +32,8 @@ module AWS::SessionStore::DynamoDB::Locking
 
     # @return [String] Session data.
     def extract_data(env, result = nil)
-      env['rack.initial_data'] = result[:item]["data"][:s] if result[:item]
-      unpack_data(result[:item]["data"][:s]) if result[:item]
+      env['rack.initial_data'] = result.item["data"] if result.item
+      unpack_data(result.item["data"]) if result.item
     end
 
   end

--- a/lib/aws/session_store/dynamo_db/locking/pessimistic.rb
+++ b/lib/aws/session_store/dynamo_db/locking/pessimistic.rb
@@ -12,11 +12,11 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB::Locking
+module Aws::SessionStore::DynamoDB::Locking
   # This class implements a pessimistic locking strategy for the
   # DynamoDB session handler. Sessions obtain an exclusive lock
   # for reads that is only released when the session is saved.
-  class Pessimistic < AWS::SessionStore::DynamoDB::Locking::Base
+  class Pessimistic < Aws::SessionStore::DynamoDB::Locking::Base
     WAIT_ERROR =
 
     # Saves the session.
@@ -43,7 +43,7 @@ module AWS::SessionStore::DynamoDB::Locking
         exceeded_wait_time?(max_attempt_date)
         begin
           result = attempt_set_lock(sid)
-        rescue AWS::DynamoDB::Errors::ConditionalCheckFailedException
+        rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
           expires_at ||= get_expire_date(sid)
           next if expires_at.nil?
           result = bust_lock(sid, expires_at)
@@ -58,7 +58,7 @@ module AWS::SessionStore::DynamoDB::Locking
     # @raise [Error] When time for attempting to get lock has
     #   been exceeded.
     def exceeded_wait_time?(max_attempt_date)
-      lock_error = AWS::SessionStore::DynamoDB::LockWaitTimeoutError
+      lock_error = Aws::SessionStore::DynamoDB::LockWaitTimeoutError
       raise lock_error if Time.now.to_f > max_attempt_date
     end
 
@@ -70,15 +70,19 @@ module AWS::SessionStore::DynamoDB::Locking
     # @return [Time] Time stamp for which the session was locked.
     def lock_time(sid)
       result = @config.dynamo_db_client.get_item(get_lock_time_opts(sid))
-      (result[:item]["locked_at"][:n]).to_f if result[:item]["locked_at"]
+      (result.item['locked_at']).to_f if result.item['locked_at']
     end
 
     # @return [String] Session data.
     def get_data(env, result)
-      lock_time = result[:attributes]["locked_at"][:n]
-      env["locked_at"] = (lock_time).to_f
-      env['rack.initial_data'] = result[:item]["data"][:s] if result[:item]
-      unpack_data(result[:attributes]["data"][:s])
+      attributes = result[:attributes]
+
+      lock_time = attributes['locked_at']
+      env['locked_at'] = (lock_time).to_f
+
+      data = attributes['data']
+      env['rack.initial_data'] = data
+      unpack_data(data)
     end
 
     # Attempt to bust the lock if the expiration date has expired.
@@ -119,7 +123,7 @@ module AWS::SessionStore::DynamoDB::Locking
 
     # Time in which session was updated.
     def updated_at
-      { :value => {:n => "#{(Time.now).to_f}"}, :action  => "PUT" }
+      { :value => "#{(Time.now).to_f}", :action  => "PUT" }
     end
 
     # Attributes for locking.
@@ -147,7 +151,7 @@ module AWS::SessionStore::DynamoDB::Locking
     # Expectation of when lock was set.
     def expect_lock_time(env)
       { :expected => {"locked_at" => {
-        :value => {:n => "#{env["locked_at"]}"}, :exists => true}} }
+        :value => "#{env["locked_at"]}", :exists => true}} }
     end
 
     # Attributes to be retrieved via client

--- a/lib/aws/session_store/dynamo_db/missing_secret_key_error.rb
+++ b/lib/aws/session_store/dynamo_db/missing_secret_key_error.rb
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   class MissingSecretKeyError < RuntimeError
     def initialize(msg = "No secret key provided!")
       super

--- a/lib/aws/session_store/dynamo_db/rack_middleware.rb
+++ b/lib/aws/session_store/dynamo_db/rack_middleware.rb
@@ -15,7 +15,7 @@ require 'rack/session/abstract/id'
 require 'openssl'
 require 'aws-sdk'
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   # This class is an ID based Session Store Rack Middleware
   # that uses a DynamoDB backend for session storage.
   class RackMiddleware < Rack::Session::Abstract::ID
@@ -24,9 +24,9 @@ module AWS::SessionStore::DynamoDB
     #
     # @param app Rack application.
     # @option (see Configuration#initialize)
-    # @raise [AWS::DynamoDB::Errors::ResourceNotFoundException] If valid table
+    # @raise [Aws::DynamoDB::Errors::ResourceNotFoundException] If valid table
     #   name is not provided.
-    # @raise [AWS::SessionStore::DynamoDB::MissingSecretKey] If secret key is
+    # @raise [Aws::SessionStore::DynamoDB::MissingSecretKey] If secret key is
     #   not provided.
     def initialize(app, options = {})
       super
@@ -42,16 +42,16 @@ module AWS::SessionStore::DynamoDB
     # @return [Locking::Pessimistic] If locking is enabled.
     def set_locking_strategy
       if @config.enable_locking
-        @lock = AWS::SessionStore::DynamoDB::Locking::Pessimistic.new(@config)
+        @lock = Aws::SessionStore::DynamoDB::Locking::Pessimistic.new(@config)
       else
-        @lock = AWS::SessionStore::DynamoDB::Locking::Null.new(@config)
+        @lock = Aws::SessionStore::DynamoDB::Locking::Null.new(@config)
       end
     end
 
     # Determines if the correct session table name is being used for
     # this application. Also tests existence of secret key.
     #
-    # @raise [AWS::DynamoDB::Errors::ResourceNotFoundException] If wrong table
+    # @raise [Aws::DynamoDB::Errors::ResourceNotFoundException] If wrong table
     #   name.
     def validate_config
       raise MissingSecretKeyError unless @config.secret_key
@@ -99,8 +99,8 @@ module AWS::SessionStore::DynamoDB
     def handle_error(env = nil, &block)
       begin
         yield
-      rescue AWS::DynamoDB::Errors::Base,
-             AWS::SessionStore::DynamoDB::InvalidIDError => e
+      rescue Aws::DynamoDB::Errors::Base,
+             Aws::SessionStore::DynamoDB::InvalidIDError => e
         @config.error_handler.handle_error(e, env)
       end
     end

--- a/lib/aws/session_store/dynamo_db/railtie.rb
+++ b/lib/aws/session_store/dynamo_db/railtie.rb
@@ -12,10 +12,10 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   class Railtie < Rails::Railtie
     initializer 'aws-sessionstore-dynamodb-rack-middleware' do
-      ActionDispatch::Session::DynamodbStore = AWS::SessionStore::DynamoDB::RackMiddleware
+      ActionDispatch::Session::DynamodbStore = Aws::SessionStore::DynamoDB::RackMiddleware
     end
 
     # Load all rake tasks

--- a/lib/aws/session_store/dynamo_db/table.rb
+++ b/lib/aws/session_store/dynamo_db/table.rb
@@ -28,7 +28,7 @@ module Aws::SessionStore::DynamoDB
         )
       config.dynamo_db_client.create_table(ddb_options)
       logger << "Table #{config.table_name} created, waiting for activation...\n"
-      # block_until_created(config)
+      block_until_created(config) unless options[:no_create_table_block]
       logger << "Table #{config.table_name} is now ready to use.\n"
     rescue Aws::DynamoDB::Errors::ResourceInUseException
       logger << "Table #{config.table_name} already exists, skipping creation.\n"

--- a/lib/aws/session_store/dynamo_db/table.rb
+++ b/lib/aws/session_store/dynamo_db/table.rb
@@ -14,7 +14,7 @@
 require 'aws-sdk'
 require 'logger'
 
-module AWS::SessionStore::DynamoDB
+module Aws::SessionStore::DynamoDB
   # This class provides a way to create and delete a session table.
   module Table
     module_function
@@ -30,7 +30,7 @@ module AWS::SessionStore::DynamoDB
       logger << "Table #{config.table_name} created, waiting for activation...\n"
       block_until_created(config)
       logger << "Table #{config.table_name} is now ready to use.\n"
-    rescue AWS::DynamoDB::Errors::ResourceInUseException
+    rescue Aws::DynamoDB::Errors::ResourceInUseException
       logger << "Table #{config.table_name} already exists, skipping creation.\n"
     end
 
@@ -50,7 +50,7 @@ module AWS::SessionStore::DynamoDB
     # @option (see Configuration#initialize)
     # @api private
     def load_config(options = {})
-      AWS::SessionStore::DynamoDB::Configuration.new(options)
+      Aws::SessionStore::DynamoDB::Configuration.new(options)
     end
 
     # @return [Hash] Attribute settings for creating a session table.

--- a/lib/aws/session_store/dynamo_db/table.rb
+++ b/lib/aws/session_store/dynamo_db/table.rb
@@ -28,7 +28,7 @@ module Aws::SessionStore::DynamoDB
         )
       config.dynamo_db_client.create_table(ddb_options)
       logger << "Table #{config.table_name} created, waiting for activation...\n"
-      block_until_created(config)
+      # block_until_created(config)
       logger << "Table #{config.table_name} is now ready to use.\n"
     rescue Aws::DynamoDB::Errors::ResourceInUseException
       logger << "Table #{config.table_name} already exists, skipping creation.\n"

--- a/lib/aws/session_store/dynamo_db/tasks/session_table.rake
+++ b/lib/aws/session_store/dynamo_db/tasks/session_table.rake
@@ -15,7 +15,7 @@ namespace "db" do
   namespace "sessions" do
     desc 'Clean up old sessions in Amazon DynamoDB session store'
     task :cleanup => :environment do |t|
-      AWS::SessionStore::DynamoDB::GarbageCollection.collect_garbage
+      Aws::SessionStore::DynamoDB::GarbageCollection.collect_garbage
     end
   end
 end

--- a/lib/aws/session_store/dynamo_db/version.rb
+++ b/lib/aws/session_store/dynamo_db/version.rb
@@ -12,10 +12,10 @@
 # language governing permissions and limitations under the License.
 
 
-module AWS
+module Aws
   module SessionStore
     module DynamoDB
-      VERSION = "0.5.0"
+      VERSION = "0.6.0"
     end
   end
 end

--- a/lib/rails/generators/sessionstore/dynamodb/templates/sessionstore/dynamodb.yml
+++ b/lib/rails/generators/sessionstore/dynamodb/templates/sessionstore/dynamodb.yml
@@ -17,19 +17,19 @@ secret_key: <%= require 'securerandom'; SecureRandom.hex(64) %>
 
 # [Boolean] Define as true or false depending on if you want a strongly
 # consistent read.
-# See AWS DynamoDB documentation for table consistent_read for more
+# See Aws DynamoDB documentation for table consistent_read for more
 # information on this setting.
 #
 # consistent_read: true
 
 # [Integer] Maximum number of reads consumed per second before
-# DynamoDB returns a ThrottlingException. See AWS DynamoDB documentation
+# DynamoDB returns a ThrottlingException. See Aws DynamoDB documentation
 # or table read_capacity for more information on this setting.
 #
 # read_capacity: 10
 
 # [Integer] Maximum number of writes consumed per second before
-# DynamoDB returns a ThrottlingException. See AWS DynamoDB documentation
+# DynamoDB returns a ThrottlingException. See Aws DynamoDB documentation
 # or table write_capacity for more information on this setting.
 #
 # write_capacity: 5

--- a/lib/rails/generators/sessionstore/dynamodb/templates/sessionstore_migration.rb
+++ b/lib/rails/generators/sessionstore/dynamodb/templates/sessionstore_migration.rb
@@ -1,10 +1,10 @@
 class <%= name.camelize %> < ActiveRecord::Migration
   def up
-    AWS::SessionStore::DynamoDB::Table.create_table
+    Aws::SessionStore::DynamoDB::Table.create_table
   end
 
   def down
-    AWS::SessionStore::DynamoDB::Table.delete_table
+    Aws::SessionStore::DynamoDB::Table.delete_table
   end
 end
 

--- a/spec/aws/session_store/dynamo_db/app_config.yml
+++ b/spec/aws/session_store/dynamo_db/app_config.yml
@@ -13,6 +13,7 @@
 
   table_name: NewTable
   table_key: Somekey
+  user_key: UserId
   consistent_read: true
   access_key_id: FakeKey
   secret_access_key: Secret

--- a/spec/aws/session_store/dynamo_db/app_config.yml
+++ b/spec/aws/session_store/dynamo_db/app_config.yml
@@ -14,6 +14,6 @@
   table_name: NewTable
   table_key: Somekey
   consistent_read: true
-  AWS_ACCESS_KEY_ID: FakeKey
-  AWS_SECRET_ACCESS_KEY: Secret
-  AWS_REGION: New York
+  access_key_id: FakeKey
+  secret_access_key: Secret
+  region: us-west-1

--- a/spec/aws/session_store/dynamo_db/config/dynamo_db_session.yml
+++ b/spec/aws/session_store/dynamo_db/config/dynamo_db_session.yml
@@ -17,8 +17,8 @@ test:
   table_name: NewTable
   table_key: Somekey
   consistent_read: true
-  AWS_ACCESS_KEY_ID: FakeKey
-  AWS_SECRET_ACCESS_KEY: Secret
-  AWS_REGION: New York
+  access_key_id: FakeKey
+  secret_access_key: Secret
+  region: us-west-1
 production:
   key1: production value 1

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -29,11 +29,11 @@ describe Aws::SessionStore::DynamoDB::Configuration do
   let(:expected_file_opts) do
     {
       :consistent_read => true,
-      :AWS_ACCESS_KEY_ID => 'FakeKey',
-      :AWS_REGION => 'New York',
+      :access_key_id => 'FakeKey',
+      :region => 'us-west-1',
       :table_name => 'NewTable',
       :table_key => 'Somekey',
-      :AWS_SECRET_ACCESS_KEY => 'Secret'
+      :secret_access_key => 'Secret'
     }
   end
 

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -13,7 +13,7 @@
 
 require "spec_helper"
 
-describe AWS::SessionStore::DynamoDB::Configuration do
+describe Aws::SessionStore::DynamoDB::Configuration do
 
   let(:defaults) do
     {
@@ -45,19 +45,19 @@ describe AWS::SessionStore::DynamoDB::Configuration do
   end
 
   def expected_options(opts)
-    cfg = AWS::SessionStore::DynamoDB::Configuration.new(opts)
+    cfg = Aws::SessionStore::DynamoDB::Configuration.new(opts)
     expected_opts = defaults.merge(expected_file_opts).merge(opts)
     cfg.to_hash.should include(expected_opts)
   end
 
   context "Configuration Tests" do
     it "configures option with out runtime,YAML or ENV options" do
-      cfg = AWS::SessionStore::DynamoDB::Configuration.new
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new
       cfg.to_hash.should include(defaults)
     end
 
     it "configures accurate option hash with runtime options, no YAML or ENV" do
-      cfg = AWS::SessionStore::DynamoDB::Configuration.new(runtime_options)
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new(runtime_options)
       expected_opts = defaults.merge(runtime_options)
       cfg.to_hash.should include(expected_opts)
     end
@@ -79,7 +79,7 @@ describe AWS::SessionStore::DynamoDB::Configuration do
     it "has rails defiend but no file specified, no error thrown" do
       rails = double('Rails', {:env => 'test', :root => ''})
       stub_const("Rails", rails)
-      cfg = AWS::SessionStore::DynamoDB::Configuration.new(runtime_options)
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new(runtime_options)
       expected_opts = defaults.merge(runtime_options)
       cfg.to_hash.should include(expected_opts)
     end
@@ -87,7 +87,7 @@ describe AWS::SessionStore::DynamoDB::Configuration do
     it "has rails defiend but and default rails YAML file loads" do
       rails = double('Rails', {:env => 'test', :root => File.dirname(__FILE__)})
       stub_const("Rails", rails)
-      cfg = AWS::SessionStore::DynamoDB::Configuration.new(runtime_options)
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new(runtime_options)
       expected_opts = defaults.merge(runtime_options)
       cfg.to_hash.should include(expected_opts)
     end
@@ -95,7 +95,7 @@ describe AWS::SessionStore::DynamoDB::Configuration do
     it "throws an exception when wrong path for file" do
       config_path = 'Wrong path!'
       runtime_opts = {:config_file => config_path}.merge(runtime_options)
-      expect{cfg = AWS::SessionStore::DynamoDB::Configuration.new(runtime_opts)}.to raise_error(Errno::ENOENT)
+      expect{cfg = Aws::SessionStore::DynamoDB::Configuration.new(runtime_opts)}.to raise_error(Errno::ENOENT)
     end
   end
 end

--- a/spec/aws/session_store/dynamo_db/error/default_error_handler_spec.rb
+++ b/spec/aws/session_store/dynamo_db/error/default_error_handler_spec.rb
@@ -34,12 +34,12 @@ describe Aws::SessionStore::DynamoDB do
     end
 
     it "catches exception for inaccurate table name and raises error " do
-      client.stub_responses(:update_item, resource_error)
+      client.stub_responses(:update_item, resource_error.new(nil,nil))
       lambda { get "/" }.should raise_error(resource_error)
     end
 
     it "catches exception for inaccurate table key" do
-      client.stub_responses(:update_item, Aws::DynamoDB::Errors::ValidationException)
+      client.stub_responses(:update_item, Aws::DynamoDB::Errors::ValidationException.new(nil,'stubbed error'))
       client.stub_responses(:get_item, Aws::DynamoDB::Errors::ValidationException)
       get "/"
       last_request.env["rack.errors"].string.should include('stubbed error')
@@ -49,13 +49,13 @@ describe Aws::SessionStore::DynamoDB do
   context "Test ExceptionHandler with true as return value for handle_error" do
     it "raises all errors" do
       @options[:raise_errors] = true
-      client.stub_responses(:update_item, client_error)
+      client.stub_responses(:update_item, client_error.new(nil,nil))
       lambda { get "/" }.should raise_error(client_error)
     end
 
     it "catches exception for inaccurate table key and raises error" do
       @options[:raise_errors] = true
-      client.stub_responses(:update_item, Aws::DynamoDB::Errors::ValidationException)
+      client.stub_responses(:update_item, Aws::DynamoDB::Errors::ValidationException.new(nil,nil))
       lambda { get "/" }.should raise_error(Aws::DynamoDB::Errors::ValidationException)
     end
   end

--- a/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
+++ b/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
@@ -108,7 +108,10 @@ describe Aws::SessionStore::DynamoDB::GarbageCollection do
 
     it "gets scan results then returns last evaluated key and resumes scanning" do
       dynamo_db_client.should_receive(:scan).
-        exactly(2).times.and_return(scan_resp2, scan_resp3)
+        exactly(1).times.and_return(scan_resp2)
+      dynamo_db_client.should_receive(:scan).
+        exactly(1).times.with(hash_including({:exclusive_start_key => scan_resp2.last_evaluated_key})).
+        and_return(scan_resp3)
       dynamo_db_client.should_receive(:batch_write_item).
         exactly(3).times.and_return(write_resp1)
         collect_garbage

--- a/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
+++ b/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
@@ -13,11 +13,11 @@
 
 require 'spec_helper'
 
-describe AWS::SessionStore::DynamoDB::GarbageCollection do
+describe Aws::SessionStore::DynamoDB::GarbageCollection do
   def member(min,max)
     member = []
     for i in min..max
-      member << {"session_id"=>{:s=>"#{i}"}}
+      member << {"session_id"=>"#{i}"}
     end
     member
   end
@@ -25,7 +25,7 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
   def format_scan_result
     member = []
     for i in 31..49
-      member << {"session_id"=>{:s=>"#{i}"}}
+      member << {"session_id"=>"#{i}"}
     end
 
     member.inject([]) do |rqst_array, item|
@@ -36,7 +36,7 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
 
   def collect_garbage
     options = { :dynamo_db_client => dynamo_db_client, :max_age => 100, :max_stale => 100 }
-    AWS::SessionStore::DynamoDB::GarbageCollection.collect_garbage(options)
+    Aws::SessionStore::DynamoDB::GarbageCollection.collect_garbage(options)
   end
 
   let(:scan_resp1){
@@ -51,7 +51,7 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
   let(:scan_resp2){
     {
       :member => member(0, 31),
-      :last_evaluated_key => {"session_id"=>{:s=>"31"}}
+      :last_evaluated_key => {"session_id"=>"31"}
     }
   }
 
@@ -75,20 +75,14 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
           {
             :delete_request => {
               :key => {
-                "session_id" =>
-                {
-                  :s => "1"
-                }
+                "session_id" => "1"
               }
             }
           },
           {
             :delete_request => {
               :key => {
-                "session_id" =>
-                {
-                  :s => "17"
-                }
+                "session_id" => "17"
               }
             }
           }
@@ -97,7 +91,7 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
     }
   }
 
-  let(:dynamo_db_client) {AWS::DynamoDB::Client.new}
+  let(:dynamo_db_client) {Aws::DynamoDB::Client.new}
 
   context "Mock DynamoDB client with garbage collection" do
 
@@ -130,20 +124,14 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
             {
               :delete_request => {
                 :key => {
-                  "session_id" =>
-                  {
-                    :s => "1"
-                  }
+                  "session_id" => "1"
                 }
               }
             },
             {
               :delete_request => {
                 :key => {
-                  "session_id" =>
-                  {
-                    :s => "17"
-                  }
+                  "session_id" => "17"
                 }
               }
             }

--- a/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
+++ b/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
@@ -41,25 +41,28 @@ describe Aws::SessionStore::DynamoDB::GarbageCollection do
 
   let(:scan_resp1){
     resp = {
-      :member => member(0, 49),
+      :items => member(0, 49),
       :count => 50,
       :scanned_count => 1000,
       :last_evaluated_key => {}
     }
+    Struct.new(*resp.keys).new(*resp.values)
   }
 
   let(:scan_resp2){
-    {
-      :member => member(0, 31),
+    resp = {
+      :items => member(0, 31),
       :last_evaluated_key => {"session_id"=>"31"}
     }
+    Struct.new(*resp.keys).new(*resp.values)
   }
 
   let(:scan_resp3){
-    {
-      :member => member(31,49),
+    resp = {
+      :items => member(31,49),
       :last_evaluated_key => {}
     }
+    Struct.new(*resp.keys).new(*resp.values)
   }
 
   let(:write_resp1){

--- a/spec/aws/session_store/dynamo_db/locking/threaded_sessions_spec.rb
+++ b/spec/aws/session_store/dynamo_db/locking/threaded_sessions_spec.rb
@@ -14,7 +14,7 @@
 
 require 'spec_helper'
 
-describe AWS::SessionStore::DynamoDB::RackMiddleware do
+describe Aws::SessionStore::DynamoDB::RackMiddleware do
   include Rack::Test::Methods
 
   def thread(mul_val, time, check)
@@ -39,11 +39,11 @@ describe AWS::SessionStore::DynamoDB::RackMiddleware do
   end
 
   let(:base_app) { MultiplierApplication.new }
-  let(:app) { AWS::SessionStore::DynamoDB::RackMiddleware.new(base_app, @options) }
+  let(:app) { Aws::SessionStore::DynamoDB::RackMiddleware.new(base_app, @options) }
 
   context "Mock Multiple Threaded Sessions", :integration => true do
     before do
-      @options = AWS::SessionStore::DynamoDB::Configuration.new.to_hash
+      @options = Aws::SessionStore::DynamoDB::Configuration.new.to_hash
       @options[:enable_locking] = true
       @options[:secret_key] = 'watermelon_smiles'
 
@@ -71,7 +71,7 @@ describe AWS::SessionStore::DynamoDB::RackMiddleware do
       get "/"
       last_request.session[:multiplier].should eq(1)
 
-      t1 = thread_exception(AWS::DynamoDB::Errors::ConditionalCheckFailedException)
+      t1 = thread_exception(Aws::DynamoDB::Errors::ConditionalCheckFailedException)
       t2 = thread(2, 0.25, true)
       t1.join
       t2.join
@@ -87,7 +87,7 @@ describe AWS::SessionStore::DynamoDB::RackMiddleware do
 
       t1 = thread(2, 0, false)
       sleep(0.25)
-      t2 = thread_exception(AWS::SessionStore::DynamoDB::LockWaitTimeoutError)
+      t2 = thread_exception(Aws::SessionStore::DynamoDB::LockWaitTimeoutError)
       t1.join
       t2.join
     end

--- a/spec/aws/session_store/dynamo_db/rack_middleware_database_spec.rb
+++ b/spec/aws/session_store/dynamo_db/rack_middleware_database_spec.rb
@@ -63,7 +63,7 @@ module Aws
             last_response['Set-Cookie'].should be_truthy
           end
 
-          it "does not rewrite Cookie if cookie previously/accuarately set" do
+          it "does not rewrite Cookie if cookie previously/accurately set" do
             get "/"
             last_response['Set-Cookie'].should_not be_nil
 

--- a/spec/aws/session_store/dynamo_db/rack_middleware_database_spec.rb
+++ b/spec/aws/session_store/dynamo_db/rack_middleware_database_spec.rb
@@ -13,7 +13,7 @@
 
 require 'spec_helper'
 
-module AWS
+module Aws
   module SessionStore
     module DynamoDB
       describe RackMiddleware do
@@ -29,7 +29,7 @@ module AWS
         def table_opts(sid)
           {
             :table_name => Configuration::DEFAULTS[:table_name],
-            :key => { Configuration::DEFAULTS[:table_key] => { :s => sid } }
+            :key => { Configuration::DEFAULTS[:table_key] => sid }
           }
         end
 
@@ -43,7 +43,7 @@ module AWS
 
         def extract_time(sid)
           options = table_opts(sid).merge(attr_opts)
-          Time.at((client.get_item(options)[:item]["created_at"][:n]).to_f)
+          Time.at((client.get_item(options).item["created_at"]).to_f)
         end
 
         let(:base_app) { MultiplierApplication.new }
@@ -60,7 +60,7 @@ module AWS
           it "creates a new HTTP cookie when Cookie not supplied" do
             get "/"
             last_response.body.should eq('All good!')
-            last_response['Set-Cookie'].should be_true
+            last_response['Set-Cookie'].should be_truthy
           end
 
           it "does not rewrite Cookie if cookie previously/accuarately set" do
@@ -120,7 +120,7 @@ module AWS
 
             get "/"
             options = table_opts(sid).merge(attr_opts)
-            client.get_item(options)[:item]["locked_at"].should be_nil
+            client.get_item(options).item["locked_at"].should be_nil
           end
         end
       end

--- a/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
+++ b/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
@@ -13,7 +13,7 @@
 
 require 'spec_helper'
 
-module AWS
+module Aws
   module SessionStore
     module DynamoDB
       describe RackMiddleware do
@@ -46,15 +46,11 @@ module AWS
         end
 
         let(:dynamo_db_client) do
-          client = double('AWS::DynamoDB::Client')
-          client.stub(:delete_item) { 'Deleted' }
-          client.stub(:list_tables) { {:table_names => ['Sessions']} }
-          client.stub(:get_item) do
-            { :item => { 'data' => { :s => sample_packed_data } } }
-          end
-          client.stub(:update_item) do
-            { :attributes => { :created_at => 'now' } }
-          end
+          client = Aws::DynamoDB::Client.new(stub_responses: true)
+          client.stub_responses(:delete_item, true)
+          client.stub_responses(:list_tables, {:table_names => ['Sessions']})
+          client.stub_responses(:get_item, Struct.new(:item).new({'data' => sample_packed_data}))
+          client.stub_responses(:update_item, {:attributes => {'created_at' => {:s => 'now'}}})
           client
         end
 
@@ -67,7 +63,7 @@ module AWS
           it "creates a new HTTP cookie when Cookie not supplied" do
             get "/"
             last_response.body.should eq('All good!')
-            last_response['Set-Cookie'].should be_true
+            last_response['Set-Cookie'].should be_truthy
           end
 
           it "loads/manipulates a session based on id from HTTP-Cookie" do

--- a/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
+++ b/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
@@ -74,7 +74,7 @@ module Aws
             last_request.session.to_hash.should eq("multiplier" => 2)
           end
 
-          it "does not rewrite Cookie if cookie previously/accuarately set" do
+          it "does not rewrite Cookie if cookie previously/accurately set" do
             get "/"
             last_response['Set-Cookie'].should_not be_nil
 

--- a/spec/aws/session_store/dynamo_db/rails_app_config.yml
+++ b/spec/aws/session_store/dynamo_db/rails_app_config.yml
@@ -17,8 +17,9 @@ test:
   table_name: NewTable
   table_key: Somekey
   consistent_read: true
-  AWS_ACCESS_KEY_ID: FakeKey
-  AWS_SECRET_ACCESS_KEY: Secret
-  AWS_REGION: New York
+  access_key_id: FakeKey
+  secret_access_key: Secret
+  region: us-west-1
+
 production:
   key1: production value 1

--- a/spec/aws/session_store/dynamo_db/table_spec.rb
+++ b/spec/aws/session_store/dynamo_db/table_spec.rb
@@ -15,7 +15,7 @@ require 'spec_helper'
 require 'stringio'
 require 'logger'
 
-module AWS
+module Aws
   module SessionStore
     module DynamoDB
       describe Table do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,23 +39,21 @@ end
 
 ConstantHelpers = lambda do
   let(:token_error_msg) { 'The security token included in the request is invalid' }
-  let(:resource_error) { AWS::DynamoDB::Errors::ResourceNotFoundException }
-  let(:key_error) { AWS::DynamoDB::Errors::ValidationException.new(key_error_msg) }
-  let(:key_error_msg) { 'The provided key element does not match the schema' }
-  let(:client_error) { AWS::DynamoDB::Errors::UnrecognizedClientException }
+  let(:resource_error) { Aws::DynamoDB::Errors::ResourceNotFoundException }
+  let(:client_error) { Aws::DynamoDB::Errors::UnrecognizedClientException }
   let(:invalid_cookie) { {"HTTP_COOKIE" => "rack.session=ApplePieBlueberries"} }
   let(:invalid_session_data) { {"rack.session"=>{"multiplier" => 1}} }
-  let(:rack_default_error_msg) { "Warning! AWS::SessionStore::DynamoDB failed to save session. Content dropped.\n" }
-  let(:missing_key_error) { AWS::SessionStore::DynamoDB::MissingSecretKeyError }
+  let(:rack_default_error_msg) { "Warning! Aws::SessionStore::DynamoDB failed to save session. Content dropped.\n" }
+  let(:missing_key_error) { Aws::SessionStore::DynamoDB::MissingSecretKeyError }
 end
 
 RSpec.configure do |c|
   c.before(:each, :integration => true) do
     opts = {:table_name => 'sessionstore-integration-test'}
 
-    defaults = AWS::SessionStore::DynamoDB::Configuration::DEFAULTS
+    defaults = Aws::SessionStore::DynamoDB::Configuration::DEFAULTS
     defaults = defaults.merge(opts)
-    stub_const("AWS::SessionStore::DynamoDB::Configuration::DEFAULTS", defaults)
-    AWS::SessionStore::DynamoDB::Table.create_table(opts)
+    stub_const("Aws::SessionStore::DynamoDB::Configuration::DEFAULTS", defaults)
+    Aws::SessionStore::DynamoDB::Table.create_table(opts)
   end
 end


### PR DESCRIPTION
This is a slightly modified version of aws/aws-sessionstore-dynamodb-ruby/pull/4 but includes an updated spec test for the issue.