### PR TITLE
Avoid infinite loop during session garbage collection.

### DIFF
--- a/lib/aws/session_store/dynamo_db/garbage_collection.rb
+++ b/lib/aws/session_store/dynamo_db/garbage_collection.rb
@@ -59,7 +59,7 @@ module AWS::SessionStore::DynamoDB
     # @api private
     def scan(config, last_item = nil)
       options = scan_opts(config)
-      options.merge(start_key(last_item)) if last_item
+      options = options.merge(start_key(last_item)) if last_item
       config.dynamo_db_client.scan(options)
     end
 

--- a/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
+++ b/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
@@ -111,7 +111,10 @@ describe AWS::SessionStore::DynamoDB::GarbageCollection do
 
     it "gets scan results then returns last evaluated key and resumes scanning" do
       dynamo_db_client.should_receive(:scan).
-        exactly(2).times.and_return(scan_resp2, scan_resp3)
+        exactly(1).times.and_return(scan_resp2)
+      dynamo_db_client.should_receive(:scan).
+        exactly(1).times.with(hash_including({:exclusive_start_key => scan_resp2.last_evaluated_key})).
+        and_return(scan_resp3)
       dynamo_db_client.should_receive(:batch_write_item).
         exactly(3).times.and_return(write_resp1)
         collect_garbage


### PR DESCRIPTION
This is the same issue as #4 but this PR includes updated spec test.

The GarbageColection#scan method was not properly using the last_item parameter. This causes the #scan to repeatedly rescan the same set of DDB items instead of advancing through the items in the table. If all / many sessions were expired the gc would seem to work since gc deletes old sessions; however, for a real live system, the gc will appear to hang.