### PR TITLE
Remove expected attributes from delete options.

### DIFF
--- a/lib/aws/session_store/dynamo_db/locking/base.rb
+++ b/lib/aws/session_store/dynamo_db/locking/base.rb
@@ -65,7 +65,7 @@ module Aws::SessionStore::DynamoDB::Locking
 
     # @return [Hash] Options for deleting session.
     def delete_opts(sid)
-      merge_all(table_opts(sid), expected_attributes(sid))
+      table_opts(sid)
     end
 
     # @return [Hash] Options for updating item in Session table.


### PR DESCRIPTION
@cjyclaire here is a rebased PR to replace https://github.com/aws/aws-sessionstore-dynamodb-ruby/pull/11

fixes #10 