### PR TITLE
Don't use a client subset for config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased Changes
 ------------------
 
+* Issue - Expose `:config` in `RackMiddleware` and `:config_file` in `Configuration`.
+
+* Issue - V2 of this release was still loading SDK V1 credential keys. This removes support for client options specified in YAML configuration (behavior change). Instead, construct `Aws::DynamoDB::Client` and use the `dynamo_db_client` option.
+
 2.0.0 (2020-11-11)
 ------------------
 

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -114,6 +114,9 @@ module Aws::SessionStore::DynamoDB
     # @return [String] The secret key for HMAC encryption.
     attr_reader :secret_key
 
+    # @return [String,Pathname]
+    attr_reader :config_file
+
     ### Client and Error Handling options
 
     # @return [DynamoDB Client] DynamoDB client.

--- a/lib/aws/session_store/dynamo_db/rack_middleware.rb
+++ b/lib/aws/session_store/dynamo_db/rack_middleware.rb
@@ -6,6 +6,9 @@ module Aws::SessionStore::DynamoDB
   # This class is an ID based Session Store Rack Middleware
   # that uses a DynamoDB backend for session storage.
   class RackMiddleware < Rack::Session::Abstract::Persisted
+    # @return [Configuration] An instance of Configuration that is used for
+    #   this middleware.
+    attr_reader :config
 
     # Initializes SessionStore middleware.
     #

--- a/spec/aws/session_store/dynamo_db/app_config.yml
+++ b/spec/aws/session_store/dynamo_db/app_config.yml
@@ -14,6 +14,3 @@
 table_name: NewTable
 table_key: Somekey
 consistent_read: true
-AWS_ACCESS_KEY_ID: FakeKey
-AWS_SECRET_ACCESS_KEY: Secret
-AWS_REGION: New York

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -30,13 +30,12 @@ describe Aws::SessionStore::DynamoDB::Configuration do
   let(:expected_file_opts) do
     {
       consistent_read: true,
-      AWS_ACCESS_KEY_ID: 'FakeKey',
-      AWS_REGION: 'New York',
       table_name: 'NewTable',
       table_key: 'Somekey',
-      AWS_SECRET_ACCESS_KEY: 'Secret'
     }
   end
+
+  let(:client) { Aws::DynamoDB::Client.new(stub_responses: true) }
 
   let(:runtime_options) do
     {
@@ -49,6 +48,10 @@ describe Aws::SessionStore::DynamoDB::Configuration do
     cfg = Aws::SessionStore::DynamoDB::Configuration.new(opts)
     expected_opts = defaults.merge(expected_file_opts).merge(opts)
     expect(cfg.to_hash).to include(expected_opts)
+  end
+
+  before do
+    allow(Aws::DynamoDB::Client).to receive(:new).and_return(client)
   end
 
   context 'Configuration Tests' do

--- a/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
+++ b/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
@@ -98,7 +98,7 @@ describe Aws::SessionStore::DynamoDB::GarbageCollection do
     }
   end
 
-  let(:dynamo_db_client) {Aws::DynamoDB::Client.new}
+  let(:dynamo_db_client) {Aws::DynamoDB::Client.new(stub_responses: true)}
 
   context 'Mock DynamoDB client with garbage collection' do
     it 'processes scan result greater than 25 and deletes in batches of 25' do


### PR DESCRIPTION
BYOC

Don't use a client subset for configuration - customers can pass a custom client as dynamo_db_client