### PR TITLE
Make Rack Middleware methods public for Rails Abstract implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Unreleased Changes
 
 * Feature - Moves Error classes into the Errors module.
 
+* Issue - Set `find_session`, `write_session`, and `delete_session` as public.
+
+* Issue - Validate `Configuration` has secret_key on `:initialize` instead of on `:find_session`.
+
 2.2.0 (2024-01-25)
 ------------------
 


### PR DESCRIPTION
Long term fix of https://github.com/aws/aws-sdk-rails/issues/76

This makes the find, write, and delete session methods public so that aws-sdk-rails can use a delegator to `RackMiddleware` after inheriting from `ActionDispatch::Session::AbstractStore`