### PR TITLE
Use ENV with precedence over YAML configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - `Configuration` now takes environment variables with precedence over YAML configuration.
+
 3.0.0 (2024-10-29)
 ------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'json', '2.7.5' if defined?(JRUBY_VERSION) #temporary
+
 gem 'rake', require: false
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'json', '2.7.5' if defined?(JRUBY_VERSION) #temporary
+gem 'json', '2.7.5' if defined?(JRUBY_VERSION) # temporary
 
 gem 'rake', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'json', '2.7.5' if defined?(JRUBY_VERSION) # temporary
-
 gem 'rake', require: false
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -37,17 +37,12 @@ gem 'aws-sdk-rails', '~> 4'
 
 A number of options are available to be set in
 `Aws::SessionStore::DynamoDB::Configuration`, which is used throughout the
-application. These options can be set directly by Ruby code, through
-a YAML configuration file, or Environment variables, in order of precedence.
+application. These options can be set directly in Ruby code, in ENV variables,
+or in a YAML configuration file, in order of precedence.
 
 The full set of options along with defaults can be found in the
 [Configuration](https://docs.aws.amazon.com/sdk-for-ruby/aws-sessionstore-dynamodb/api/Aws/SessionStore/DynamoDB/Configuration.html)
 documentation.
-
-### YAML Configuration
-
-You can create a YAML configuration file to set the options. The file must be
-passed into Configuration as the `:config_file` option.
 
 ### Environment Options
 
@@ -61,6 +56,12 @@ directly if needed. The environment options must be prefixed with
 The example below would be a valid way to set the session table name:
 
     export DYNAMO_DB_SESSION_TABLE_NAME='your-table-name'
+
+### YAML Configuration
+
+You can create a YAML configuration file to set the options. The file must be
+passed into Configuration as the `:config_file` option or with the
+`DYNAMO_DB_SESSION_CONFIG_FILE` environment variable.
 
 ## Creating the session table
 

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -166,7 +166,8 @@ module Aws::SessionStore::DynamoDB
       require 'erb'
       require 'yaml'
       opts = YAML.safe_load(ERB.new(File.read(file_path)).result) || {}
-      opts.transform_keys(&:to_sym)
+      unsupported_keys = %i[dynamo_db_client error_handler config_file]
+      opts.transform_keys(&:to_sym).reject { |k, _| unsupported_keys.include?(k) }
     end
 
     def set_attributes(options)

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -4,7 +4,7 @@ require 'aws-sdk-dynamodb'
 
 module Aws::SessionStore::DynamoDB
   # This class provides a Configuration object for all DynamoDB session store operations
-  # by pulling configuration options from Runtime, a YAML file, the ENV, and default
+  # by pulling configuration options from Runtime, the ENV, a YAML file, and default
   # settings, in that order.
   #
   # == Environment Variables
@@ -63,7 +63,7 @@ module Aws::SessionStore::DynamoDB
     }.freeze
 
     # Provides configuration object that allows access to options defined
-    # during Runtime, in a YAML file, in the ENV, and by default.
+    # during Runtime, in the ENV, in a YAML file, and by default.
     #
     # @option options [String] :table_name ("sessions") Name of the session table.
     # @option options [String] :table_key ("session_id") The hash key of the session table.
@@ -99,8 +99,9 @@ module Aws::SessionStore::DynamoDB
     # @option options [Aws::DynamoDB::Client] :dynamo_db_client (Aws::DynamoDB::Client.new)
     #   DynamoDB client used to perform database operations inside of the rack application.
     def initialize(options = {})
-      opts = file_options(options).merge(options)
+      opts = options
       opts = env_options.merge(opts)
+      opts = file_options(opts).merge(opts)
       MEMBERS.each_pair do |opt_name, default_value|
         opts[opt_name] = default_value unless opts.key?(opt_name)
       end
@@ -145,13 +146,10 @@ module Aws::SessionStore::DynamoDB
     end
 
     def parse_env_value(key)
-      Integer(ENV.fetch(key, nil))
+      val = ENV.fetch(key, nil)
+      Integer(val)
     rescue ArgumentError
-      if ENV[key] == 'true' || ENV[key] == 'false'
-        ENV[key] == 'true'
-      else
-        ENV.fetch(key, nil)
-      end
+      %w[true false].include?(val) ? val == 'true' : val
     end
 
     # @return [Hash] File options.

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -25,13 +25,13 @@ describe Aws::SessionStore::DynamoDB::Configuration do
     }
   end
 
-  def setup_env
+  def setup_env(options)
     options.each do |k, v|
       ENV["DYNAMO_DB_SESSION_#{k.to_s.upcase}"] = v.to_s
     end
   end
 
-  def teardown_env
+  def teardown_env(options)
     options.each_key { |k| ENV.delete("DYNAMO_DB_SESSION_#{k.to_s.upcase}") }
   end
 
@@ -41,44 +41,52 @@ describe Aws::SessionStore::DynamoDB::Configuration do
     allow(Aws::DynamoDB::Client).to receive(:new).and_return(client)
   end
 
-  it 'configures defaults without runtime, YAML or ENV options' do
+  it 'configures defaults without runtime, ENV, or YAML options' do
     cfg = Aws::SessionStore::DynamoDB::Configuration.new
     expect(cfg.to_hash).to include(defaults)
   end
 
-  it 'configures with ENV with precedence over defaults' do
-    setup_env
-    cfg = Aws::SessionStore::DynamoDB::Configuration.new
-    expect(cfg.to_hash).to include(options)
-    teardown_env
+  it 'configures with YAML with precedence over defaults' do
+    Tempfile.create('dynamo_db_session_store.yml') do |f|
+      f << options.transform_keys(&:to_s).to_yaml
+      f.rewind
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new(config_file: f.path)
+      expect(cfg.to_hash).to include(options)
+    end
   end
 
-  it 'configs with YAML with precedence over ENV' do
-    setup_env
+  it 'configs with ENV with precedence over YAML' do
+    setup_env(options)
+    Tempfile.create('dynamo_db_session_store.yml') do |f|
+      f << { table_name: 'OldTable', table_key: 'OldKey' }.transform_keys(&:to_s).to_yaml
+      f.rewind
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new(config_file: f.path)
+      expect(cfg.to_hash).to include(options)
+    end
+    teardown_env(options)
+  end
+
+  it 'configures in code with full precedence' do
+    old = { table_name: 'OldTable', table_key: 'OldKey' }
+    setup_env(options.merge(old))
+    Tempfile.create('dynamo_db_session_store.yml') do |f|
+      f << old.transform_keys(&:to_s).to_yaml
+      f.rewind
+      cfg = Aws::SessionStore::DynamoDB::Configuration.new(options.merge(config_file: f.path))
+      expect(cfg.to_hash).to include(options)
+    end
+    teardown_env(options.merge(old))
+  end
+
+  it 'allows for config file to be configured with ENV' do
     Tempfile.create('dynamo_db_session_store.yml') do |f|
       f << options.transform_keys(&:to_s).to_yaml
       f.rewind
       ENV['DYNAMO_DB_SESSION_CONFIG_FILE'] = f.path
       cfg = Aws::SessionStore::DynamoDB::Configuration.new
+      expect(cfg.to_hash).to include(options)
       ENV.delete('DYNAMO_DB_SESSION_CONFIG_FILE')
-      expect(cfg.to_hash).to include(options)
     end
-    teardown_env
-  end
-
-  it 'configures with runtime options with full precedence' do
-    setup_env
-    Tempfile.create('dynamo_db_session_store.yml') do |f|
-      f << { table_name: 'OldTable', table_key: 'OldKey' }.transform_keys(&:to_s).to_yaml
-      f.rewind
-      cfg = Aws::SessionStore::DynamoDB::Configuration.new(
-        options.merge(
-          config_file: f.path
-        )
-      )
-      expect(cfg.to_hash).to include(options)
-    end
-    teardown_env
   end
 
   it 'raises an exception when wrong path for file' do

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -55,7 +55,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
     end
   end
 
-  it 'configs with ENV with precedence over YAML' do
+  it 'configures with ENV with precedence over YAML' do
     setup_env(options)
     Tempfile.create('dynamo_db_session_store.yml') do |f|
       f << { table_name: 'OldTable', table_key: 'OldKey' }.transform_keys(&:to_s).to_yaml
@@ -92,7 +92,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
     end
   end
 
-  it 'ignores certain keys in ENV' do
+  it 'ignores unsupported keys in ENV' do
     ENV['DYNAMO_DB_SESSION_DYNAMO_DB_CLIENT'] = 'Client'
     ENV['DYNAMO_DB_SESSION_ERROR_HANDLER'] = 'Handler'
     cfg = Aws::SessionStore::DynamoDB::Configuration.new
@@ -102,7 +102,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
     ENV.delete('DYNAMO_DB_SESSION_ERROR_HANDLER')
   end
 
-  it 'ignores certain keys in YAML' do
+  it 'ignores unsupported keys in YAML' do
     Tempfile.create('dynamo_db_session_store.yml') do |f|
       options = { dynamo_db_client: 'Client', error_handler: 'Handler', config_file: 'File' }
       f << options.transform_keys(&:to_s).to_yaml

--- a/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
+++ b/spec/aws/session_store/dynamo_db/garbage_collection_spec.rb
@@ -4,17 +4,14 @@ require 'spec_helper'
 
 describe Aws::SessionStore::DynamoDB::GarbageCollection do
   def items(min, max)
-    items = []
-    (min..max).each do |i|
-      items << { 'session_id' => { s: i.to_s } }
+    (min..max).map do |i|
+      { 'session_id' => { s: i.to_s } }
     end
-    items
   end
 
   def format_scan_result
-    items = []
-    (31..49).each do |i|
-      items << { 'session_id' => { s: i.to_s } }
+    items = (31..49).map do |i|
+      { 'session_id' => { s: i.to_s } }
     end
 
     items.each_with_object([]) do |item, rqst_array|


### PR DESCRIPTION
Related to discussions in https://github.com/aws/aws-sdk-rails/issues/139

Soft breaking change. This change makes ENV variables take precedence over YAML files, similar to how it works in the Ruby SDK. This is necessary so that the config file path can be set in ENV, then that config file, if present, would be read and used. The values in the config file would not take precedence over ENV.