### PR TITLE
Use AWS_ prefixed environment keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@ documentation.
 All Configuration options can be loaded from the environment except for
 `:dynamo_db_client` and `:error_handler`, which must be set in Ruby code
 directly if needed. The environment options must be prefixed with
-`DYNAMO_DB_SESSION_` and then the name of the option:
+`AWS_DYNAMO_DB_SESSION_` and then the name of the option:
 
-    DYNAMO_DB_SESSION_<name-of-option>
+    AWS_DYNAMO_DB_SESSION_<name-of-option>
 
 The example below would be a valid way to set the session table name:
 
-    export DYNAMO_DB_SESSION_TABLE_NAME='your-table-name'
+    export AWS_DYNAMO_DB_SESSION_TABLE_NAME='your-table-name'
 
 ### YAML Configuration
 
 You can create a YAML configuration file to set the options. The file must be
 passed into Configuration as the `:config_file` option or with the
-`DYNAMO_DB_SESSION_CONFIG_FILE` environment variable.
+`AWS_DYNAMO_DB_SESSION_CONFIG_FILE` environment variable.
 
 ## Creating the session table
 

--- a/aws-sessionstore-dynamodb.gemspec
+++ b/aws-sessionstore-dynamodb.gemspec
@@ -14,10 +14,11 @@ Gem::Specification.new do |spec|
   spec.license      = 'Apache-2.0'
   spec.files        = Dir['LICENSE', 'CHANGELOG.md', 'VERSION', 'lib/**/*']
 
-  # Require 1.85.0 for user_agent_frameworks config
-  spec.add_dependency 'aws-sdk-dynamodb', '~> 1', '>= 1.85.0'
   spec.add_dependency 'rack', '~> 3'
   spec.add_dependency 'rack-session', '~> 2'
+
+  # Require 1.85.0 for user_agent_frameworks config
+  spec.add_dependency 'aws-sdk-dynamodb', '~> 1', '>= 1.85.0'
 
   spec.required_ruby_version = '>= 2.7'
 end

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -138,19 +138,23 @@ module Aws::SessionStore::DynamoDB
     def env_options
       unsupported_keys = %i[dynamo_db_client error_handler]
       (MEMBERS.keys - unsupported_keys).each_with_object({}) do |opt_name, opts|
-        # legacy - remove this in aws-sessionstore-dynamodb ~> 4
-        key = "DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}"
-        if ENV.key?(key)
-          Kernel.warn("The environment variable `#{key}` is deprecated.
-                       Please use `AWS_DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}` instead.")
-        else
-          key = "AWS_DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}"
-          next unless ENV.key?(key)
-        end
-
+        key = env_key(opt_name)
+        next unless ENV.key?(key)
 
         opts[opt_name] = parse_env_value(key)
       end
+    end
+
+    def env_key(opt_name)
+      # legacy - remove this in aws-sessionstore-dynamodb ~> 4
+      key = "DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}"
+      if ENV.key?(key)
+        Kernel.warn("The environment variable `#{key}` is deprecated.
+                     Please use `AWS_DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}` instead.")
+      else
+        key = "AWS_DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}"
+      end
+      key
     end
 
     def parse_env_value(key)

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -10,10 +10,10 @@ module Aws::SessionStore::DynamoDB
   # == Environment Variables
   # The Configuration object can load default values from your environment. All configuration
   # keys are supported except for `:dynamo_db_client` and `:error_handler`. The keys take the form
-  # of DYNAMO_DB_SESSION_<KEY_NAME>. Example:
+  # of AWS_DYNAMO_DB_SESSION_<KEY_NAME>. Example:
   #
-  #   export DYNAMO_DB_SESSION_TABLE_NAME='Sessions'
-  #   export DYNAMO_DB_SESSION_TABLE_KEY='id'
+  #   export AWS_DYNAMO_DB_SESSION_TABLE_NAME='Sessions'
+  #   export AWS_DYNAMO_DB_SESSION_TABLE_KEY='id'
   #
   # == Locking Strategy
   # By default, locking is disabled for session store access. To enable locking, set the
@@ -138,8 +138,16 @@ module Aws::SessionStore::DynamoDB
     def env_options
       unsupported_keys = %i[dynamo_db_client error_handler]
       (MEMBERS.keys - unsupported_keys).each_with_object({}) do |opt_name, opts|
+        # legacy - remove this in aws-sessionstore-dynamodb ~> 4
         key = "DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}"
-        next unless ENV.key?(key)
+        if ENV.key?(key)
+          Kernel.warn("The environment variable `#{key}` is deprecated.
+                       Please use `AWS_DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}` instead.")
+        else
+          key = "AWS_DYNAMO_DB_SESSION_#{opt_name.to_s.upcase}"
+          next unless ENV.key?(key)
+        end
+
 
         opts[opt_name] = parse_env_value(key)
       end

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -47,7 +47,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
   end
 
   it 'configures with YAML with precedence over defaults' do
-    Tempfile.create('AWS_DYNAMO_DB_SESSION_store.yml') do |f|
+    Tempfile.create('aws_dynamo_db_session_store.yml') do |f|
       f << options.transform_keys(&:to_s).to_yaml
       f.rewind
       cfg = Aws::SessionStore::DynamoDB::Configuration.new(config_file: f.path)
@@ -57,7 +57,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
 
   it 'configures with ENV with precedence over YAML' do
     setup_env(options)
-    Tempfile.create('AWS_DYNAMO_DB_SESSION_store.yml') do |f|
+    Tempfile.create('aws_dynamo_db_session_store.yml') do |f|
       f << { table_name: 'OldTable', table_key: 'OldKey' }.transform_keys(&:to_s).to_yaml
       f.rewind
       cfg = Aws::SessionStore::DynamoDB::Configuration.new(config_file: f.path)

--- a/spec/aws/session_store/dynamo_db/configuration_spec.rb
+++ b/spec/aws/session_store/dynamo_db/configuration_spec.rb
@@ -27,12 +27,12 @@ describe Aws::SessionStore::DynamoDB::Configuration do
 
   def setup_env(options)
     options.each do |k, v|
-      ENV["DYNAMO_DB_SESSION_#{k.to_s.upcase}"] = v.to_s
+      ENV["AWS_DYNAMO_DB_SESSION_#{k.to_s.upcase}"] = v.to_s
     end
   end
 
   def teardown_env(options)
-    options.each_key { |k| ENV.delete("DYNAMO_DB_SESSION_#{k.to_s.upcase}") }
+    options.each_key { |k| ENV.delete("AWS_DYNAMO_DB_SESSION_#{k.to_s.upcase}") }
   end
 
   let(:client) { Aws::DynamoDB::Client.new(stub_responses: true) }
@@ -47,7 +47,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
   end
 
   it 'configures with YAML with precedence over defaults' do
-    Tempfile.create('dynamo_db_session_store.yml') do |f|
+    Tempfile.create('AWS_DYNAMO_DB_SESSION_store.yml') do |f|
       f << options.transform_keys(&:to_s).to_yaml
       f.rewind
       cfg = Aws::SessionStore::DynamoDB::Configuration.new(config_file: f.path)
@@ -57,7 +57,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
 
   it 'configures with ENV with precedence over YAML' do
     setup_env(options)
-    Tempfile.create('dynamo_db_session_store.yml') do |f|
+    Tempfile.create('AWS_DYNAMO_DB_SESSION_store.yml') do |f|
       f << { table_name: 'OldTable', table_key: 'OldKey' }.transform_keys(&:to_s).to_yaml
       f.rewind
       cfg = Aws::SessionStore::DynamoDB::Configuration.new(config_file: f.path)
@@ -70,7 +70,7 @@ describe Aws::SessionStore::DynamoDB::Configuration do
   it 'configures in code with full precedence' do
     old = { table_name: 'OldTable', table_key: 'OldKey' }
     setup_env(options.merge(old))
-    Tempfile.create('dynamo_db_session_store.yml') do |f|
+    Tempfile.create('aws_dynamo_db_session_store.yml') do |f|
       f << old.transform_keys(&:to_s).to_yaml
       f.rewind
       cfg = Aws::SessionStore::DynamoDB::Configuration.new(options.merge(config_file: f.path))
@@ -81,29 +81,29 @@ describe Aws::SessionStore::DynamoDB::Configuration do
   end
 
   it 'allows for config file to be configured with ENV' do
-    Tempfile.create('dynamo_db_session_store.yml') do |f|
+    Tempfile.create('aws_dynamo_db_session_store.yml') do |f|
       f << options.transform_keys(&:to_s).to_yaml
       f.rewind
-      ENV['DYNAMO_DB_SESSION_CONFIG_FILE'] = f.path
+      ENV['AWS_DYNAMO_DB_SESSION_CONFIG_FILE'] = f.path
       cfg = Aws::SessionStore::DynamoDB::Configuration.new
       expect(cfg.to_hash).to include(options)
     ensure
-      ENV.delete('DYNAMO_DB_SESSION_CONFIG_FILE')
+      ENV.delete('AWS_DYNAMO_DB_SESSION_CONFIG_FILE')
     end
   end
 
   it 'ignores unsupported keys in ENV' do
-    ENV['DYNAMO_DB_SESSION_DYNAMO_DB_CLIENT'] = 'Client'
-    ENV['DYNAMO_DB_SESSION_ERROR_HANDLER'] = 'Handler'
+    ENV['AWS_DYNAMO_DB_SESSION_DYNAMO_DB_CLIENT'] = 'Client'
+    ENV['AWS_DYNAMO_DB_SESSION_ERROR_HANDLER'] = 'Handler'
     cfg = Aws::SessionStore::DynamoDB::Configuration.new
     expect(cfg.to_hash).to include(defaults)
   ensure
-    ENV.delete('DYNAMO_DB_SESSION_DYNAMO_DB_CLIENT')
-    ENV.delete('DYNAMO_DB_SESSION_ERROR_HANDLER')
+    ENV.delete('AWS_DYNAMO_DB_SESSION_DYNAMO_DB_CLIENT')
+    ENV.delete('AWS_DYNAMO_DB_SESSION_ERROR_HANDLER')
   end
 
   it 'ignores unsupported keys in YAML' do
-    Tempfile.create('dynamo_db_session_store.yml') do |f|
+    Tempfile.create('aws_dynamo_db_session_store.yml') do |f|
       options = { dynamo_db_client: 'Client', error_handler: 'Handler', config_file: 'File' }
       f << options.transform_keys(&:to_s).to_yaml
       f.rewind


### PR DESCRIPTION
This change uses AWS_ prefixed environment keys for consistency with other AWS products. A warning is emitted when an old key is used. The key will be removed in the new major version.