### PR TITLE
fix: Use JSON instead of marshal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install gems
         run: |
           bundle config set --local with 'test'
+          if [[ "${{ matrix.ruby }}" == jruby* ]]; then
+            echo 'gem "rdoc", "< 8"' >> Gemfile
+          fi
           bundle install
 
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Install gems
         run: |
           bundle config set --local with 'test'
-          if [[ "${{ matrix.ruby }}" == jruby* ]]; then
-            echo 'gem "rbs", "< 4"' >> Gemfile
-          fi
           bundle install
 
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install gems
         run: |
           bundle config set --local with 'test'
+          if [[ "${{ matrix.ruby }}" == jruby* ]]; then
+            echo 'gem "rbs", "< 4"' >> Gemfile
+          fi
           bundle install
 
       - name: Tests

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/ClassLength:
   Max: 150
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Replace `Marshal` with `JSON` as the default session serializer to mitigate deserialization code injection vulnerabilities. Add `:serializer` configuration option (`:json_allow_marshal`, `:json`, `:marshal`) for controlling serialization behavior. Default `:json_allow_marshal` writes JSON and falls back to reading legacy Marshal data for zero-downtime migration.
+* Feature - Replace `Marshal` with `JSON` as the default session serializer. Add `:serializer` configuration option (`:json_allow_marshal`, `:json`, `:marshal`) for controlling serialization behavior. Default `:json_allow_marshal` writes JSON and falls back to reading legacy Marshal data for zero-downtime migration.
 
 3.0.1 (2024-11-16)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Replace `Marshal` with `JSON` as the default session serializer to mitigate deserialization code injection vulnerabilities. Add `:serializer` configuration option (`:json_allow_marshal`, `:json`, `:marshal`) for controlling serialization behavior. Default `:json_allow_marshal` writes JSON and falls back to reading legacy Marshal data for zero-downtime migration.
+
 3.0.1 (2024-11-16)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Feature - Replace `Marshal` with `JSON` as the default session serializer. Add `:serializer` configuration option (`:json_allow_marshal`, `:json`, `:marshal`) for controlling serialization behavior. Default `:json_allow_marshal` writes JSON and falls back to reading legacy Marshal data for zero-downtime migration.
+* Feature - Add `:serializer` configuration option (`:marshal`, `:json`, `:json_allow_marshal`). Default remains `:marshal` for backwards compatibility. Set to `:json` or `:json_allow_marshal` to use JSON serialization for session data.
 
 3.0.1 (2024-11-16)
 ------------------

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -58,7 +58,7 @@ module Aws::SessionStore::DynamoDB
       lock_expiry_time: 500,
       lock_retry_delay: 500,
       lock_max_wait_time: 1,
-      serializer: :json_allow_marshal,
+      serializer: :marshal,
       config_file: nil,
       dynamo_db_client: nil
     }.freeze
@@ -95,7 +95,7 @@ module Aws::SessionStore::DynamoDB
     #   to obtain lock once an attempt to obtain the lock has been made and has failed.
     # @option options [Integer] :lock_max_wait_time (500) Maximum time in seconds to wait to acquire the
     #   lock before giving up.
-    # @option options [Symbol] :serializer (:json_allow_marshal) The serializer for session data.
+    # @option options [Symbol] :serializer (:marshal) The serializer for session data.
     #   - `:json` - Serialize and deserialize with JSON only. Raises an error if legacy
     #     Marshal-encoded data is encountered.
     #   - `:json_allow_marshal` - Serialize with JSON, but fall back to deserializing with

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -101,7 +101,7 @@ module Aws::SessionStore::DynamoDB
     #   - `:json_allow_marshal` - Serialize with JSON, but fall back to deserializing with
     #     Marshal if JSON parsing fails. Use this during migration from Marshal to JSON.
     #   - `:marshal` - Serialize and deserialize with Marshal only (legacy behavior, not
-    #     recommended due to security concerns).
+    #     recommended).
     #
     #   Note: When using `:json` or `:json_allow_marshal`, session data must consist of
     #   JSON-compatible types only (strings, numbers, booleans, arrays, hashes with string

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -102,6 +102,11 @@ module Aws::SessionStore::DynamoDB
     #     Marshal if JSON parsing fails. Use this during migration from Marshal to JSON.
     #   - `:marshal` - Serialize and deserialize with Marshal only (legacy behavior, not
     #     recommended due to security concerns).
+    #
+    #   Note: When using `:json` or `:json_allow_marshal`, session data must consist of
+    #   JSON-compatible types only (strings, numbers, booleans, arrays, hashes with string
+    #   keys). Symbol keys are converted to strings, and complex objects (e.g., Time, custom
+    #   classes) are not preserved across serialization.
     # @option options [String, Pathname] :config_file
     #   Path to a YAML file that contains configuration options.
     # @option options [Aws::DynamoDB::Client] :dynamo_db_client (Aws::DynamoDB::Client.new)

--- a/lib/aws/session_store/dynamo_db/configuration.rb
+++ b/lib/aws/session_store/dynamo_db/configuration.rb
@@ -58,6 +58,7 @@ module Aws::SessionStore::DynamoDB
       lock_expiry_time: 500,
       lock_retry_delay: 500,
       lock_max_wait_time: 1,
+      serializer: :json_allow_marshal,
       config_file: nil,
       dynamo_db_client: nil
     }.freeze
@@ -94,6 +95,13 @@ module Aws::SessionStore::DynamoDB
     #   to obtain lock once an attempt to obtain the lock has been made and has failed.
     # @option options [Integer] :lock_max_wait_time (500) Maximum time in seconds to wait to acquire the
     #   lock before giving up.
+    # @option options [Symbol] :serializer (:json_allow_marshal) The serializer for session data.
+    #   - `:json` - Serialize and deserialize with JSON only. Raises an error if legacy
+    #     Marshal-encoded data is encountered.
+    #   - `:json_allow_marshal` - Serialize with JSON, but fall back to deserializing with
+    #     Marshal if JSON parsing fails. Use this during migration from Marshal to JSON.
+    #   - `:marshal` - Serialize and deserialize with Marshal only (legacy behavior, not
+    #     recommended due to security concerns).
     # @option options [String, Pathname] :config_file
     #   Path to a YAML file that contains configuration options.
     # @option options [Aws::DynamoDB::Client] :dynamo_db_client (Aws::DynamoDB::Client.new)

--- a/lib/aws/session_store/dynamo_db/locking/base.rb
+++ b/lib/aws/session_store/dynamo_db/locking/base.rb
@@ -74,11 +74,29 @@ module Aws::SessionStore::DynamoDB::Locking
     end
 
     def pack_data(data)
-      JSON.dump(data)
+      case @config.serializer
+      when :marshal
+        [Marshal.dump(data)].pack('m*')
+      else
+        JSON.dump(data)
+      end
     end
 
     def unpack_data(packed_data)
+      case @config.serializer
+      when :marshal
+        Marshal.load(packed_data.unpack1('m*'))
+      when :json
+        JSON.parse(packed_data)
+      when :json_allow_marshal
+        handle_unpack_data_fallback(packed_data)
+      end
+    end
+
+    def handle_unpack_data_fallback(packed_data)
       JSON.parse(packed_data)
+    rescue JSON::ParserError
+      Marshal.load(packed_data.unpack1('m*'))
     end
 
     # Table options for client.

--- a/lib/aws/session_store/dynamo_db/locking/base.rb
+++ b/lib/aws/session_store/dynamo_db/locking/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module Aws::SessionStore::DynamoDB::Locking
   # Handles session management.
   class Base
@@ -71,14 +73,12 @@ module Aws::SessionStore::DynamoDB::Locking
       merge_all(table_opts(sid), attribute_opts)
     end
 
-    # Marshal the data.
     def pack_data(data)
-      [Marshal.dump(data)].pack('m*')
+      JSON.dump(data)
     end
 
-    # Unmarshal the data.
     def unpack_data(packed_data)
-      Marshal.load(packed_data.unpack1('m*'))
+      JSON.parse(packed_data)
     end
 
     # Table options for client.

--- a/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
+++ b/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Aws
+  module SessionStore
+    module DynamoDB
+      module Locking
+        describe Base do
+          let(:dynamo_db_client) do
+            Aws::DynamoDB::Client.new(stub_responses: true)
+          end
+
+          let(:options) do
+            {
+              dynamo_db_client: dynamo_db_client,
+              secret_key: 'test_key'
+            }
+          end
+
+          let(:config) { Configuration.new(options) }
+          let(:handler) { Base.new(config) }
+          let(:session_data) { { 'user_id' => 123, 'name' => 'test' } }
+
+          describe '#pack_data / #unpack_data' do
+            context 'with serializer: :json (default via :json_allow_marshal)' do
+              it 'packs data as JSON' do
+                packed = handler.send(:pack_data, session_data)
+                expect(packed).to eq('{"user_id":123,"name":"test"}')
+              end
+
+              it 'unpacks JSON data' do
+                packed = JSON.dump(session_data)
+                unpacked = handler.send(:unpack_data, packed)
+                expect(unpacked).to eq(session_data)
+              end
+            end
+
+            context 'with serializer: :json_allow_marshal' do
+              it 'unpacks legacy Base64-encoded Marshal data' do
+                legacy_packed = [Marshal.dump(session_data)].pack('m*')
+                unpacked = handler.send(:unpack_data, legacy_packed)
+                expect(unpacked).to eq(session_data)
+              end
+
+              it 'prefers JSON when data is valid JSON' do
+                json_packed = JSON.dump(session_data)
+                unpacked = handler.send(:unpack_data, json_packed)
+                expect(unpacked).to eq(session_data)
+              end
+
+              it 'packs new data as JSON, not Marshal' do
+                packed = handler.send(:pack_data, session_data)
+                expect { JSON.parse(packed) }.not_to raise_error
+              end
+            end
+
+            context 'with serializer: :json' do
+              let(:options) do
+                {
+                  dynamo_db_client: dynamo_db_client,
+                  secret_key: 'test_key',
+                  serializer: :json
+                }
+              end
+
+              it 'packs data as JSON' do
+                packed = handler.send(:pack_data, session_data)
+                expect(packed).to eq('{"user_id":123,"name":"test"}')
+              end
+
+              it 'unpacks JSON data' do
+                packed = JSON.dump(session_data)
+                unpacked = handler.send(:unpack_data, packed)
+                expect(unpacked).to eq(session_data)
+              end
+
+              it 'raises on legacy Marshal data' do
+                legacy_packed = [Marshal.dump(session_data)].pack('m*')
+                expect { handler.send(:unpack_data, legacy_packed) }.to raise_error(JSON::ParserError)
+              end
+            end
+
+            context 'with serializer: :marshal' do
+              let(:options) do
+                {
+                  dynamo_db_client: dynamo_db_client,
+                  secret_key: 'test_key',
+                  serializer: :marshal
+                }
+              end
+
+              it 'packs data as Base64-encoded Marshal' do
+                packed = handler.send(:pack_data, session_data)
+                unpacked = Marshal.load(packed.unpack1('m*'))
+                expect(unpacked).to eq(session_data)
+              end
+
+              it 'unpacks Base64-encoded Marshal data' do
+                packed = [Marshal.dump(session_data)].pack('m*')
+                unpacked = handler.send(:unpack_data, packed)
+                expect(unpacked).to eq(session_data)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
+++ b/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
@@ -92,7 +92,7 @@ module Aws
 
               it 'packs data as Base64-encoded Marshal' do
                 packed = handler.send(:pack_data, session_data)
-                unpacked = Marshal.load(packed.unpack1('m*'))
+                unpacked = Marshal.load(packed.unpack1('m*')) # rubocop:disable Security/MarshalLoad
                 expect(unpacked).to eq(session_data)
               end
 

--- a/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
+++ b/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
@@ -89,7 +89,6 @@ module Aws
                 expect { handler.send(:unpack_data, legacy_packed) }.to raise_error(JSON::ParserError)
               end
             end
-
           end
         end
       end

--- a/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
+++ b/spec/aws/session_store/dynamo_db/locking/serializer_spec.rb
@@ -23,20 +23,29 @@ module Aws
           let(:session_data) { { 'user_id' => 123, 'name' => 'test' } }
 
           describe '#pack_data / #unpack_data' do
-            context 'with serializer: :json (default via :json_allow_marshal)' do
-              it 'packs data as JSON' do
+            context 'with serializer: :marshal (default)' do
+              it 'packs data as Base64-encoded Marshal' do
                 packed = handler.send(:pack_data, session_data)
-                expect(packed).to eq('{"user_id":123,"name":"test"}')
+                unpacked = Marshal.load(packed.unpack1('m*')) # rubocop:disable Security/MarshalLoad
+                expect(unpacked).to eq(session_data)
               end
 
-              it 'unpacks JSON data' do
-                packed = JSON.dump(session_data)
+              it 'unpacks Base64-encoded Marshal data' do
+                packed = [Marshal.dump(session_data)].pack('m*')
                 unpacked = handler.send(:unpack_data, packed)
                 expect(unpacked).to eq(session_data)
               end
             end
 
             context 'with serializer: :json_allow_marshal' do
+              let(:options) do
+                {
+                  dynamo_db_client: dynamo_db_client,
+                  secret_key: 'test_key',
+                  serializer: :json_allow_marshal
+                }
+              end
+
               it 'unpacks legacy Base64-encoded Marshal data' do
                 legacy_packed = [Marshal.dump(session_data)].pack('m*')
                 unpacked = handler.send(:unpack_data, legacy_packed)
@@ -81,27 +90,6 @@ module Aws
               end
             end
 
-            context 'with serializer: :marshal' do
-              let(:options) do
-                {
-                  dynamo_db_client: dynamo_db_client,
-                  secret_key: 'test_key',
-                  serializer: :marshal
-                }
-              end
-
-              it 'packs data as Base64-encoded Marshal' do
-                packed = handler.send(:pack_data, session_data)
-                unpacked = Marshal.load(packed.unpack1('m*')) # rubocop:disable Security/MarshalLoad
-                expect(unpacked).to eq(session_data)
-              end
-
-              it 'unpacks Base64-encoded Marshal data' do
-                packed = [Marshal.dump(session_data)].pack('m*')
-                unpacked = handler.send(:unpack_data, packed)
-                expect(unpacked).to eq(session_data)
-              end
-            end
           end
         end
       end

--- a/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
+++ b/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
@@ -29,7 +29,7 @@ module Aws
         let(:app) { RackMiddleware.new(base_app, options) }
 
         let(:sample_packed_data) do
-          [Marshal.dump('multiplier' => 1)].pack('m*')
+          JSON.dump('multiplier' => 1)
         end
 
         let(:dynamo_db_client) do

--- a/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
+++ b/spec/aws/session_store/dynamo_db/rack_middleware_spec.rb
@@ -29,7 +29,7 @@ module Aws
         let(:app) { RackMiddleware.new(base_app, options) }
 
         let(:sample_packed_data) do
-          JSON.dump('multiplier' => 1)
+          [Marshal.dump('multiplier' => 1)].pack('m*')
         end
 
         let(:dynamo_db_client) do
@@ -123,6 +123,66 @@ module Aws
 
           ensure_data_updated(false)
           get '/', {}, { 'rack.session' => { 'multiplier' => nil } }
+        end
+
+        context 'with serializer: :json' do
+          let(:options) do
+            {
+              dynamo_db_client: dynamo_db_client,
+              secret_key: 'watermelon_cherries',
+              serializer: :json
+            }
+          end
+
+          let(:sample_packed_data) do
+            JSON.dump('multiplier' => 1)
+          end
+
+          it 'stores and retrieves session data as JSON' do
+            get '/'
+            expect(last_request.session.to_hash).to eq('multiplier' => 1)
+          end
+
+          it 'loads/manipulates a session based on id from HTTP-Cookie' do
+            get '/'
+            expect(last_request.session.to_hash).to eq('multiplier' => 1)
+
+            get '/'
+            expect(last_request.session.to_hash).to eq('multiplier' => 2)
+          end
+
+          it 'raises JSON::ParserError on legacy Marshal data' do
+            marshal_data = [Marshal.dump('multiplier' => 1)].pack('m*')
+            handler = Locking::Base.new(Configuration.new(options))
+            expect { handler.send(:unpack_data, marshal_data) }.to raise_error(JSON::ParserError)
+          end
+        end
+
+        context 'with serializer: :json_allow_marshal' do
+          let(:options) do
+            {
+              dynamo_db_client: dynamo_db_client,
+              secret_key: 'watermelon_cherries',
+              serializer: :json_allow_marshal
+            }
+          end
+
+          let(:sample_packed_data) do
+            [Marshal.dump('multiplier' => 1)].pack('m*')
+          end
+
+          it 'reads legacy Marshal data via fallback' do
+            get '/'
+            expect(last_request.session.to_hash).to eq('multiplier' => 1)
+          end
+
+          it 'writes new data as JSON' do
+            expect(dynamo_db_client).to receive(:update_item) do |opts|
+              data_value = opts[:attribute_updates]['data'][:value]
+              expect { JSON.parse(data_value) }.not_to raise_error
+            end
+            get '/'
+          end
         end
       end
     end


### PR DESCRIPTION
### Summary
  
  - Replaces Marshal with JSON for session data serialization to modernize library
  - Add configurable `:serializer` option with default set as `:marshal` for backward compatibility. Adds hybrid option (`:json_allow_marshal`) for migration & also `:json` for strict JSON serializer usage (no deserializing using `marshal`, period)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
